### PR TITLE
Update xpaths for changes to Rightmove HTML structure

### DIFF
--- a/rightmove_webscraper/scraper.py
+++ b/rightmove_webscraper/scraper.py
@@ -97,7 +97,7 @@ class RightmoveData:
             by (str): valid column name from `get_results` DataFrame attribute.
         """
         if not by:
-            by = "type" if self.is_commercial() else "number_bedrooms"
+            by = "type" if self.is_commercial else "number_bedrooms"
         assert by in self.get_results.columns, f"Column not found in `get_results`: {by}"
         df = self.get_results.dropna(axis=0, subset=["price"])
         groupers = {"price": ["count", "mean"]}

--- a/test_rm.py
+++ b/test_rm.py
@@ -18,7 +18,7 @@ def test_sale_residential():
     assert required_columns.issubset(set(rm.get_results.columns))
     assert len(rm.get_results) > 0
     assert isinstance(rm.page_count, int)
-    assert rm.rent_or_sale == "sale"
+    assert rm.is_commercial == False
     assert isinstance(rm.results_count, int)
     assert isinstance(rm.results_count_display, int)
     assert url == rm.url
@@ -42,7 +42,7 @@ def test_rent_residential():
     assert required_columns.issubset(set(rm.get_results.columns))
     assert len(rm.get_results) > 0
     assert isinstance(rm.page_count, int)
-    assert rm.rent_or_sale == "rent"
+    assert rm.is_commercial == False
     assert isinstance(rm.results_count, int)
     assert isinstance(rm.results_count_display, int)
     assert url == rm.url
@@ -66,7 +66,7 @@ def test_sale_commercial():
     assert required_columns.issubset(set(rm.get_results.columns))
     assert len(rm.get_results) > 0
     assert isinstance(rm.page_count, int)
-    assert rm.rent_or_sale == "sale-commercial"
+    assert rm.is_commercial == True
     assert isinstance(rm.results_count, int)
     assert isinstance(rm.results_count_display, int)
     assert url == rm.url
@@ -92,7 +92,7 @@ def test_rent_commercial():
     assert required_columns.issubset(set(rm.get_results.columns))
     assert len(rm.get_results) > 0
     assert isinstance(rm.page_count, int)
-    assert rm.rent_or_sale == "rent-commercial"
+    assert rm.is_commercial == True
     assert isinstance(rm.results_count, int)
     assert isinstance(rm.results_count_display, int)
     assert url == rm.url


### PR DESCRIPTION
You'll see a few xpath diffs like this:

```
# before
        xpath = """//span[@class="myClassName"]/text()"""
# after
        xpath = """//span[contains(@class,"myClassName")]/text()"""
```

since Rightmove now sometimes obscures class names by doing e.g. `ResultsCount_resultsCount__a3BcD`.

Also related to changes in HTML strucutre, listing titles are not a thing implied by the html structure any more, but I think the usage of titles in the codebase implies they correspond to what the new html structure calls 'propertyType'. So I renamed 'titles' to 'types' -- the column header for titles was already called "types" so I feel comfortable with this.

Also also related to changes to HTML structure, the method 'rent_or_sale' is no longer required for choosing xpaths, as its description claimed; but the method was used elsewhere to check if the search was for commercial properties, so I simplified it to do that only.

Relates to https://github.com/toby-p/rightmove_webscraper.py/issues/52 - it fixes the precise issue mentioned, and a couple more similar ones (i.e. xpaths), but not all of the problems that must be quashed to get to a working rightmove_webscraper.py in Feb 2026.

Some changes were also required for bedroom counts. This is now a new html element, not part of the 'type' string, so I added an xpath lookup for that element. Since this data does not exist on every result card, we need to iterate over every card to prevent bedroom counts being applied to the wrong data rows.

There are some test updates, but you need the fixes from https://github.com/toby-p/rightmove_webscraper.py/pull/55 for the tests to start passing.