### PR TITLE
Make changes required by having pandas>3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 lxml>=4.8.0
 numpy>=1.22.3
-pandas>=1.4.1
+pandas>=3.0.1
 requests>=2.27.1

--- a/rightmove_webscraper/scraper.py
+++ b/rightmove_webscraper/scraper.py
@@ -242,7 +242,7 @@ class RightmoveData:
         results.reset_index(inplace=True, drop=True)
 
         # Convert price column to numeric type:
-        results["price"].replace(regex=True, inplace=True, to_replace=r"\D", value=r"")
+        results["price"] = results["price"].str.replace(r"\D", "", regex=True)
         results["price"] = pd.to_numeric(results["price"])
 
         # Extract short postcode area to a separate column:
@@ -256,8 +256,8 @@ class RightmoveData:
         # Extract number of bedrooms from `type` to a separate column:
         pat = r"\b([\d][\d]?)\b"
         results["number_bedrooms"] = results["type"].astype(str).str.extract(pat, expand=True)[0]
-        results.loc[results["type"].str.contains("studio", case=False), "number_bedrooms"] = 0
         results["number_bedrooms"] = pd.to_numeric(results["number_bedrooms"])
+        results.loc[results["type"].str.contains("studio", case=False), "number_bedrooms"] = 0
 
         # Clean up annoying white spaces and newlines in `type` column:
         results["type"] = results["type"].str.strip("\n").str.strip()


### PR DESCRIPTION
Trying to run rightmove_webscraper using the version of pandas in requirements.txt didn't work. So instead I update the version of pandas.

One change was for this: https://pandas.pydata.org/pandas-docs/stable/user_guide/copy_on_write.html

And one change was to avoid triggering pandas' now-more-strict type-checking to throw an error.

Note that you won't get as far as triggering pandas-caused errors unless you first incorporate the fixes in https://github.com/toby-p/rightmove_webscraper.py/pull/54.